### PR TITLE
Fix Python syntax in example code

### DIFF
--- a/exercises/concept/black-jack/.docs/instructions.md
+++ b/exercises/concept/black-jack/.docs/instructions.md
@@ -70,7 +70,7 @@ Remember: the value of the hand with the ace needs to be as high as possible _wi
 **Hint**: if we already have an ace in hand then its value would be 11.
 
 ```python
->>> value_of_ace('6', `K`)
+>>> value_of_ace('6', 'K')
 1
 
 >>> value_of_ace('7', '3')


### PR DESCRIPTION
Replace backticks with quotes